### PR TITLE
add raw response to handleError + additional API methods

### DIFF
--- a/lib/gigya.js
+++ b/lib/gigya.js
@@ -90,7 +90,7 @@ var Gigya = function Gigya(apiKey, secret, useHttps, apiDomain, doHttpRequest) {
     }
 
     // Called if request ends in error
-    var handleError = function(err) {
+    var handleError = function(err, json) {
       // Retry if general server error or database error
       if(err.code === 50001 || err.code === 500028) {
         retries = !_.isNumber(retries) ? 1 : retries + 1;
@@ -99,7 +99,7 @@ var Gigya = function Gigya(apiKey, secret, useHttps, apiDomain, doHttpRequest) {
         }
       }
 
-      if(callback) callback(err, null);
+      if(callback) callback(err, json);
       emitter.emit('err', err);
     };
 
@@ -125,7 +125,7 @@ var Gigya = function Gigya(apiKey, secret, useHttps, apiDomain, doHttpRequest) {
         if(!_.isUndefined(json.validationErrors)) {
           e.validationErrors = json.validationErrors;
         }
-        return handleError(e);
+        return handleError(e, json);
       }
 
       // No error, pass on response
@@ -173,7 +173,6 @@ var Gigya = function Gigya(apiKey, secret, useHttps, apiDomain, doHttpRequest) {
           handleError(err);
           return;
         }
-
         handleResponse(body);
       });
     }
@@ -406,6 +405,9 @@ var Gigya = function Gigya(apiKey, secret, useHttps, apiDomain, doHttpRequest) {
   self.socialize.getUserSettings = function(params, callback) {
     return apiCall('socialize.getUserSettings', params, callback);
   }
+  self.socialize.importUser = function(params, callback) {
+    return apiCall('socialize.importUser', params, callback);
+  }
   self.socialize.logout = function(params, callback) {
     return apiCall('socialize.logout', params, callback);
   }
@@ -584,6 +586,9 @@ var Gigya = function Gigya(apiKey, secret, useHttps, apiDomain, doHttpRequest) {
   }
   self.accounts.getAccountInfo = function(params, callback) {
     return apiCall('accounts.getAccountInfo', params, callback);
+  }
+  self.accounts.getConflictingAccount = function(params, callback) {
+    return apiCall('accounts.getConflictingAccount', params, callback);
   }
   self.accounts.getPolicies = function(params, callback) {
     return apiCall('accounts.getPolicies', params, callback);


### PR DESCRIPTION
We need the raw response (regToken etc...) when an error occured and some additional API methods for a project we are doing.
Is it possible to publish this to the public npm registry?