### PR TITLE
Fixed extra request when all objects have been received

### DIFF
--- a/lib/gigya.js
+++ b/lib/gigya.js
@@ -285,7 +285,8 @@ var Gigya = function Gigya(apiKey, secret, useHttps, apiDomain, doHttpRequest) {
           }
 
           // Set cursorId if available, otherwise false will end the loop
-          cursorId = response.nextCursorId && fetchAll === true ? response.nextCursorId : false;
+          var more = response.nextCursorId && (allResponse.objectsCount < allResponse.totalCount);
+          cursorId = more && fetchAll === true ? response.nextCursorId : false;
 
           loop();
         });


### PR DESCRIPTION
I noticed that Gigya can set the `nextCursorId` property in the response even though all objects have been received. This causes node-gigya to do an extra request which ends up returning 0 objects.

This change will check if all objects have been received to avoid the superfluous request.